### PR TITLE
Move hooks to extra in composer.json to avoid invalid schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,13 @@ Add a `hooks` section to your `composer.json` and add the hooks there. The previ
 
 ```json
 {
-  "hooks": {
-    "pre-commit": "phpunit",
-    "post-commit": "echo committed",
-    "pre-push": "phpunit && echo pushing!",
-    "...": "..."
+  "extra": {
+    "hooks": {
+      "pre-commit": "phpunit",
+      "post-commit": "echo committed",
+      "pre-push": "phpunit && echo pushing!",
+      "...": "..."
+    }
   }
 }
 ```

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -17,7 +17,7 @@ class Hook
         $json = json_decode($contents, true);
         $hooks = array_merge(
             isset($json['scripts']) ? $json['scripts'] : [],
-            isset($json['hooks']) ? $json['hooks'] : []
+            isset($json['extra']['hooks']) ? $json['extra']['hooks'] : []
         );
         $validHooks = [];
 


### PR DESCRIPTION
I like your approach with git-hooks definition within composer.json, but right now your solution causes an invalid composer schema error:

```
$ composer validate
./composer.json is valid for simple usage with composer but has
strict errors that make it unable to be published as a package:
See https://getcomposer.org/doc/04-schema.md for details on the schema
The property hooks is not defined and the definition does not allow additional properties
```

The only solution I found was to move `hooks` into the `extra` section, because `extra` is the only section which allows custom definitions: https://getcomposer.org/doc/04-schema.md#extra
The new schema looks like the following:

```json
{
  "extra": {
    "hooks": {
      "pre-commit": "phpunit",
      "post-commit": "echo committed",
      "pre-push": "phpunit && echo pushing!",
      "...": "..."
    }
  }
}
```