### PR TITLE
fix: create hooks dir, when hooks dir not exists

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -38,7 +38,7 @@ class AddCommand extends Command
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {
-            mkdir($hookDir);
+            mkdir($hookDir, 0700, true);
         }
 
         foreach ($this->hooks as $hook => $script) {

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -35,6 +35,11 @@ class AddCommand extends Command
     {
         $addedHooks = [];
         $gitDir = $input->getOption('git-dir');
+        $hookDir = "{$gitDir}/hooks";
+
+        if (! is_dir($hookDir)) {
+            mkdir($hookDir);
+        }
 
         foreach ($this->hooks as $hook => $script) {
             $filename = "{$gitDir}/hooks/{$hook}";

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -31,6 +31,11 @@ class UpdateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $gitDir = $input->getOption('git-dir');
+        $hookDir = "{$gitDir}/hooks";
+
+        if (! is_dir($hookDir)) {
+            mkdir($hookDir);
+        }
 
         foreach ($this->hooks as $hook => $script) {
             $filename = "{$gitDir}/hooks/{$hook}";

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -34,7 +34,7 @@ class UpdateCommand extends Command
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {
-            mkdir($hookDir);
+            mkdir($hookDir, 0700, true);
         }
 
         foreach ($this->hooks as $hook => $script) {

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -22,17 +22,8 @@ class Hook
         );
         $validHooks = [];
 
-        //add customize hooks
-        $customizeHooks = isset($json['extra']['customize_hooks']) ?
-            $json['extra']['customize_hooks'] : [];
-        $customizeHooks = array_flip($customizeHooks);
-
         foreach ($hooks as $hook => $script) {
             if (array_key_exists($hook, self::getHooks())) {
-                $validHooks[$hook] = $script;
-            }
-
-            if (array_key_exists($hook, $customizeHooks)) {
                 $validHooks[$hook] = $script;
             }
         }

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -22,8 +22,17 @@ class Hook
         );
         $validHooks = [];
 
+        //add customize hooks
+        $customizeHooks = isset($json['extra']['customize_hooks']) ?
+            $json['extra']['customize_hooks'] : [];
+        $customizeHooks = array_flip($customizeHooks);
+
         foreach ($hooks as $hook => $script) {
             if (array_key_exists($hook, self::getHooks())) {
+                $validHooks[$hook] = $script;
+            }
+
+            if (array_key_exists($hook, $customizeHooks)) {
                 $validHooks[$hook] = $script;
             }
         }

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -120,4 +120,25 @@ class AddCommandTester extends \PHPUnit_Framework_TestCase
             $this->assertFalse(file_exists(".git/hooks/{$hook}"));
         }
     }
+
+    /**
+     * @test
+     */
+    public function it_create_git_hooks_path_when_hooks_dir_not_exists()
+    {
+        $gitDirs = ['test-git-dir', '.git'];
+
+        foreach ($gitDirs as $gitDir) {
+            if (file_exists($hookDir = "{$gitDir}/hooks")) {
+                rmdir($hookDir);
+            }
+
+            $this->commandTester->execute(['--git-dir' => $gitDir]);
+
+            foreach (array_keys(self::$hooks) as $hook) {
+                $this->assertTrue(file_exists("{$gitDir}/hooks/{$hook}"));
+                unlink("{$gitDir}/hooks/{$hook}");
+            }
+        }
+    }
 }

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -60,4 +60,29 @@ class UpdateCommandTester extends \PHPUnit_Framework_TestCase
 
         passthru("rm -rf {$gitDir}");
     }
+
+    /**
+     * @test
+     */
+    public function it_create_git_hooks_path_when_hooks_dir_not_exists()
+    {
+        $gitDirs = ['test-git-dir', '.git'];
+
+        foreach ($gitDirs as $gitDir) {
+            if (file_exists($hookDir = "{$gitDir}/hooks")) {
+                rmdir($hookDir);
+            }
+
+            $this->commandTester->execute(['--git-dir' => $gitDir]);
+
+            foreach (array_keys(self::$hooks) as $hook) {
+                $this->assertTrue(file_exists("{$gitDir}/hooks/{$hook}"));
+                unlink("{$gitDir}/hooks/{$hook}");
+            }
+
+            if ($gitDir != '.git') {
+                passthru("rm -rf {$gitDir}");
+            }
+        }
+    }
 }


### PR DESCRIPTION
create `.git/hooks` dir, when `.git/hooks` dir is not exists.