### PR TITLE
Add option to force Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Option | Description | Command
 ------ | ----------- | -------
 `no-lock` | Do not create a lock file | `cghooks add --no-lock`
 `ignore-lock` | Add the lock file to .gitignore | `cghooks add --ignore-lock`
+`force-win` | Force windows bash compatibility | `cghooks add --force-win`
 
 The `lock` file contains a list of all added hooks.
 

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -36,7 +36,7 @@ class AddCommand extends Command
     {
         $addedHooks = [];
         $gitDir = $input->getOption('git-dir');
-        $forceWindows = $input->getOption('force-win') === true;
+        $forceWindows = $input->getOption('force-win');
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -28,6 +28,7 @@ class AddCommand extends Command
             ->addOption('no-lock', 'l', InputOption::VALUE_NONE, 'Do not create a lock file')
             ->addOption('ignore-lock', 'i', InputOption::VALUE_NONE, 'Add the lock file to .gitignore')
             ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', '.git')
+            ->addOption('force-win', null, InputOption::VALUE_NONE, 'Force windows bash compatibility')
         ;
     }
 
@@ -35,6 +36,7 @@ class AddCommand extends Command
     {
         $addedHooks = [];
         $gitDir = $input->getOption('git-dir');
+        $forceWindows = $input->getOption('force-win') === true;
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {
@@ -47,7 +49,7 @@ class AddCommand extends Command
             if (file_exists($filename)) {
                 $output->writeln("<comment>{$hook} already exists</comment>");
             } else {
-                if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+                if ($forceWindows || strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
                     // On windows we need to add a SHEBANG
                     // See: https://github.com/BrainMaestro/composer-git-hooks/issues/7
                     $script = '#!/bin/bash' . PHP_EOL . $script;

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -32,7 +32,7 @@ class UpdateCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $gitDir = $input->getOption('git-dir');
-        $forceWindows = $input->getOption('force-win') === true;
+        $forceWindows = $input->getOption('force-win');
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -25,12 +25,14 @@ class UpdateCommand extends Command
             ->setDescription('Update git hooks specified in the composer config')
             ->setHelp('This command allows you to update git hooks')
             ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', '.git')
+            ->addOption('force-win', null, InputOption::VALUE_NONE, 'Force windows bash compatibility')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $gitDir = $input->getOption('git-dir');
+        $forceWindows = $input->getOption('force-win') === true;
         $hookDir = "{$gitDir}/hooks";
 
         if (! is_dir($hookDir)) {
@@ -42,7 +44,7 @@ class UpdateCommand extends Command
 
             $operation = file_exists($filename) ? 'Updated' : 'Added';
 
-            if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            if ($forceWindows || strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
                 // On windows we need to add a SHEBANG
                 // See: https://github.com/BrainMaestro/composer-git-hooks/issues/7
                 $script = '#!/bin/bash' . PHP_EOL . $script;

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -161,4 +161,20 @@ class AddCommandTester extends \PHPUnit_Framework_TestCase
 
         rmdir($hookDir);
     }
+
+    /**
+     * @test
+     */
+    public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
+    {
+        $this->commandTester->execute(['--force-win' => true]);
+
+        foreach (array_keys(self::$hooks) as $hook) {
+            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+
+            $content = file_get_contents(".git/hooks/" . $hook);
+            $this->assertNotFalse(strpos($content, "#!/bin/bash"));
+            $this->assertEquals(strpos($content, "#!/bin/bash"), 0);
+        }
+    }
 }

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -101,4 +101,22 @@ class UpdateCommandTester extends \PHPUnit_Framework_TestCase
 
         rmdir($hookDir);
     }
+
+
+    /**
+     * @test
+     */
+    public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
+    {
+        self::createHooks();
+        $this->commandTester->execute(['--force-win' => true]);
+
+        foreach (array_keys(self::$hooks) as $hook) {
+            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+
+            $content = file_get_contents(".git/hooks/" . $hook);
+            $this->assertNotFalse(strpos($content, "#!/bin/bash"));
+            $this->assertEquals(strpos($content, "#!/bin/bash"), 0);
+        }
+    }
 }


### PR DESCRIPTION
At my office we run composer inside a docker container but manage git on the host and some of the machines run Windows so we needed to generate the hooks on Linux to run on Windows.