### PR TITLE
Pass composer.json dir

### DIFF
--- a/cghooks
+++ b/cghooks
@@ -1,10 +1,10 @@
 #!/usr/bin/env php
 <?php
-
+$dir = getcwd();
 if (is_file($autoload = __DIR__ . '/vendor/autoload.php')) {
-    require $autoload;
+    require_once $autoload;
 } elseif (is_file($autoload = __DIR__ . '/../../autoload.php')) {
-    require $autoload;
+    require_once $autoload;
 } else {
     fwrite(STDERR,
         'You must set up the project dependencies, run the following commands:' . PHP_EOL .
@@ -24,7 +24,7 @@ use Symfony\Component\Console\Application;
 
 $application = new Application('Composer Git Hooks', 'v2.2.0');
 
-$hooks = Hook::getValidHooks();
+$hooks = Hook::getValidHooks($dir);
 $application->add(new AddCommand($hooks));
 $application->add(new UpdateCommand($hooks));
 $application->add(new RemoveCommand($hooks));

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -9,11 +9,13 @@ class Hook
     /**
      * Get scripts section of the composer config file.
      *
+	 * @param	$dir	string	dir where to look for composer.json
+	 *
      * @return array
      */
-    public static function getValidHooks()
+    public static function getValidHooks($dir)
     {
-        $contents = file_get_contents('composer.json');
+        $contents = file_get_contents("{$dir}/composer.json");
         $json = json_decode($contents, true);
         $hooks = array_merge(
             isset($json['scripts']) ? $json['scripts'] : [],


### PR DESCRIPTION
When the composer autoload.php file is included the current dir instantly switches to random value from some of the packages in the file. Maybe something in the composer messes the dir. Never mind composer.json dir is better to be controlled by the app.