### PR TITLE
Add a dev mode check to the docs for the install and update hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Add the following events to your `composer.json` file. The `cghooks` commands wi
 ```json
 {
     "scripts": {
-        "post-install-cmd": "vendor/bin/cghooks add --ignore-lock",
-        "post-update-cmd": "vendor/bin/cghooks update",
+        "post-install-cmd": "if [ $COMPOSER_DEV_MODE == 1 ]; then vendor/bin/cghooks add --ignore-lock; fi",
+        "post-update-cmd": "if [ $COMPOSER_DEV_MODE == 1 ]; then vendor/bin/cghooks update; fi",
         "...": "..."
     }
 }


### PR DESCRIPTION
In the docs that demonstrate how to automatically install the Git hooks with the `post-install-cmd` and `post-update-cmd` scripts, the `--no-dev` flag isn't taken into account. This means that when the application is deployed, the scripts will trigger a fatal error due to `vendor/bin/cghooks` not being present.

This updates the docs so the scripts inspect the value of the `$COMPOSER_DEV_MODE` environment variable that Composer sets based on the value of the `--no-dev` flag. This appears to be the most succinct way to check for Composer dev mode.

See the bottom of the `Defining scripts` section here for info: https://getcomposer.org/doc/articles/scripts.md#defining-scripts .