### PR TITLE
helpers: remove unused import

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -1,7 +1,5 @@
 <?php
 
-use Symfony\Component\Process\Process;
-
 if (! function_exists('create_hooks_dir')) {
     /**
      * Create hook directory if not exists.


### PR DESCRIPTION
leftover from 1bc14b8938a328550e915e1051ddcfbb02048e5d (https://github.com/BrainMaestro/composer-git-hooks/pull/26)