### PR TITLE
Change composer update to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add a `hooks` section to the `extra` section of your `composer.json` and add the
                 "php-cs-fixer fix --dry-run ." // check style
                 "phpunit"
             ],
-            "post-merge": "composer update"
+            "post-merge": "composer install"
             "...": "..."
         }
     }


### PR DESCRIPTION
I don’t see why you would want to run ‘composer update’ after a merge, but ‘composer install’ makes sense.