### PR TITLE
Remove dependency on git being installed on host

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -26,7 +26,7 @@ class AddCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Override existing git hooks')
             ->addOption('no-lock', 'l', InputOption::VALUE_NONE, 'Do not create a lock file')
             ->addOption('ignore-lock', 'i', InputOption::VALUE_NONE, 'Add the lock file to .gitignore')
-            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', git_dir())
+            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory')
             ->addOption('lock-dir', null, InputOption::VALUE_REQUIRED, 'Path to lock file directory', getcwd())
             ->addOption('force-win', null, InputOption::VALUE_NONE, 'Force windows bash compatibility')
             ->addOption('global', null, InputOption::VALUE_NONE, 'Add global git hooks')

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -25,7 +25,7 @@ abstract class Command extends SymfonyCommand
     final protected function execute(InputInterface $input, OutputInterface $output)
     {
         $this->output = $output;
-        $this->gitDir = $input->getOption('git-dir');
+        $this->gitDir = $input->getOption('git-dir') ?: git_dir();
         $this->lockDir = $input->getOption('lock-dir');
         $this->global = $input->getOption('global');
         $this->dir = trim(

--- a/src/Commands/ListCommand.php
+++ b/src/Commands/ListCommand.php
@@ -16,7 +16,7 @@ class ListCommand extends Command
             ->setName('list-hooks')
             ->setDescription('List added hooks')
             ->setHelp('This command allows you to list your git hooks')
-            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', git_dir())
+            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory')
             ->addOption('lock-dir', null, InputOption::VALUE_REQUIRED, 'Path to lock file directory', getcwd())
             ->addOption('global', null, InputOption::VALUE_NONE, 'Perform hook command globally for every git repository')
         ;

--- a/src/Commands/RemoveCommand.php
+++ b/src/Commands/RemoveCommand.php
@@ -32,7 +32,7 @@ class RemoveCommand extends Command
                 InputOption::VALUE_NONE,
                 'Delete hooks without checking the lock file'
             )
-            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', git_dir())
+            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory')
             ->addOption('lock-dir', null, InputOption::VALUE_REQUIRED, 'Path to lock file directory', getcwd())
             ->addOption('global', null, InputOption::VALUE_NONE, 'Remove global git hooks')
         ;

--- a/src/Commands/UpdateCommand.php
+++ b/src/Commands/UpdateCommand.php
@@ -16,7 +16,7 @@ class UpdateCommand extends AddCommand
             ->setName('update')
             ->setDescription('Update git hooks specified in the composer config')
             ->setHelp('This command allows you to update git hooks')
-            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory', git_dir())
+            ->addOption('git-dir', 'g', InputOption::VALUE_REQUIRED, 'Path to git directory')
             ->addOption('lock-dir', null, InputOption::VALUE_REQUIRED, 'Path to lock file directory', getcwd())
             ->addOption('force-win', null, InputOption::VALUE_NONE, 'Force windows bash compatibility')
             ->addOption('global', null, InputOption::VALUE_NONE, 'Update global git hooks')

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -47,6 +47,6 @@ if (! function_exists('git_dir')) {
      */
     function git_dir()
     {
-        return realpath(trim(shell_exec('git rev-parse --git-dir')));
+        return realpath(trim(shell_exec('git rev-parse --git-common-dir')));
     }
 }


### PR DESCRIPTION
At present the `git_dir()` helper is called (which in turn runs a `git` command) on every command even when a git path is provided. This change moves the default to only being called when `--git-dir` is not specified, it is fully backwards compatible.

This is helpful because in a containerised environment git may not be available as the developer uses git on their local machine.

Before:

```console
sam:~$ vendor/bin/cghooks update --git-dir=".git"
sh: git: not found
sh: git: not found
sh: git: not found
sh: git: not found
Updated pre-commit hook
Updated post-merge hook
```

After:

```console
sam:~$ vendor/bin/cghooks update --git-dir=".git"
Updated pre-commit hook
Updated post-merge hook
```