### PR TITLE
Removed absolute path from LOCK_FILE in .gitignore

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -134,7 +134,7 @@ class AddCommand extends Command
 
         if ($return === false) {
             file_put_contents('.gitignore', Hook::LOCK_FILE . PHP_EOL, FILE_APPEND);
-            $this->debug("Added [{$this->lockFile}] to .gitignore");
+            $this->debug(sprintf('Added [%s] to .gitignore', Hook::LOCK_FILE));
         }
     }
 

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -2,6 +2,7 @@
 
 namespace BrainMaestro\GitHooks\Commands;
 
+use BrainMaestro\GitHooks\Hook;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
@@ -132,7 +133,7 @@ class AddCommand extends Command
         $return = strpos($contents, $this->lockFile);
 
         if ($return === false) {
-            file_put_contents('.gitignore', $this->lockFile . PHP_EOL, FILE_APPEND);
+            file_put_contents('.gitignore', Hook::LOCK_FILE . PHP_EOL, FILE_APPEND);
             $this->debug("Added [{$this->lockFile}] to .gitignore");
         }
     }

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -159,10 +159,9 @@ class AddCommandTest extends TestCase
      */
     public function it_ignores_the_hook_lock_file_if_the_ignore_lock_option_is_passed()
     {
-        $currentDir = realpath(getcwd());
         $this->commandTester->execute(['--ignore-lock' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Added ' . $currentDir . '/' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
+        $this->assertContains('Added ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 


### PR DESCRIPTION
Because project folder location can be different on each development environment 