### PR TITLE
Add JSON validation check

### DIFF
--- a/src/Hook.php
+++ b/src/Hook.php
@@ -22,6 +22,13 @@ class Hook
 
         $contents = file_get_contents($composerFile);
         $json = json_decode($contents, true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            echo "ERROR: Failed to parse $composerFile: " . json_last_error_msg() . PHP_EOL;
+
+            exit(-1);
+        }
+
         $hooks = array_merge(
             isset($json['scripts']) ? $json['scripts'] : [],
             isset($json['hooks']) ? $json['hooks'] : [],


### PR DESCRIPTION
If the composer.json file has json validation errors, this will dump an error message on the screen and exit.

I realize that the use of echo and exit are probably not preferred, so you could alternately throw an exception but then you will likely end up echoing and exiting anyways because the `Hook::getValidHooks()` method is called directly from the cghooks script before the command application runs.

It seems like all of the code here is predicated on having a valid composer file so it at least makes for a better user experience.

Fixes #104 