### PR TITLE
Concat hooks with &&

### DIFF
--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -82,7 +82,7 @@ class AddCommand extends Command
         // On windows, the shebang needs to point to bash
         // See: https://github.com/BrainMaestro/composer-git-hooks/issues/7
         $shebang = ($this->windows ? '#!/bin/bash' : '#!/bin/sh') . PHP_EOL . PHP_EOL;
-        $contents = is_array($contents) ? implode(PHP_EOL, $contents) : $contents;
+        $contents = get_hook_contents($contents);
         $hookContents = $shebang . $contents . PHP_EOL;
 
         if (! $this->force && $exists) {

--- a/src/Commands/HookCommand.php
+++ b/src/Commands/HookCommand.php
@@ -29,7 +29,7 @@ class HookCommand extends SymfonyCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $contents = is_array($this->contents) ? implode(PHP_EOL, $this->contents) : $this->contents;
+        $contents = get_hook_contents($this->contents);
 
         $outputMessage = [];
         $returnCode    = 0;

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -68,6 +68,6 @@ if (! function_exists('get_hook_contents')) {
      */
     function get_hook_contents($contents)
     {
-        return is_array($contents) ? implode(" && ", $contents) : $contents;
+        return is_array($contents) ? implode(" && \\" . PHP_EOL, $contents) : $contents;
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -57,3 +57,17 @@ if (! function_exists('git_dir')) {
         return realpath($gitDir);
     }
 }
+
+if (! function_exists('get_hook_contents')) {
+    /**
+     * Return hook contents
+     *
+     * @param array|string $contents
+     *
+     * @return string
+     */
+    function get_hook_contents($contents)
+    {
+        return is_array($contents) ? implode(" && ", $contents) : $contents;
+    }
+}

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -260,7 +260,7 @@ class AddCommandTest extends TestCase
             $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(PHP_EOL, $scripts), $content);
+            $this->assertContains(implode(" && ", $scripts), $content);
         }
     }
 

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -260,7 +260,7 @@ class AddCommandTest extends TestCase
             $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(" && ", $scripts), $content);
+            $this->assertContains(implode(" && \\" . PHP_EOL, $scripts), $content);
         }
     }
 

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -24,7 +24,7 @@ class HookCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_not_continue_if_previous_hook_fail()
+    public function it_terminates_if_previous_hook_fails()
     {
         $hook = [
             'pre-commit' => [
@@ -38,5 +38,6 @@ class HookCommandTest extends TestCase
 
         $commandTester->execute([]);
         $this->assertContains('execution-error', $commandTester->getDisplay());
+        $this->assertNotContains('before-commit', $commandTester->getDisplay());
     }
 }

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -20,4 +20,23 @@ class HookCommandTest extends TestCase
             $this->assertContains(str_replace('echo ', '', $script), $commandTester->getDisplay());
         }
     }
+
+    /**
+     * @test
+     */
+    public function it_not_continue_if_previous_hook_fail()
+    {
+        $hook = [
+            'pre-commit' => [
+                'echo execution-error;exit 1',
+                'echo before-commit'
+            ],
+        ];
+
+        $command = new HookCommand('pre-commit', $hook['pre-commit']);
+        $commandTester = new CommandTester($command);
+
+        $commandTester->execute([]);
+        $this->assertContains('execution-error', $commandTester->getDisplay());
+    }
 }

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -138,7 +138,7 @@ class UpdateCommandTest extends TestCase
             $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(" && ", $scripts), $content);
+            $this->assertContains(implode(" && \\" . PHP_EOL, $scripts), $content);
         }
     }
 

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -138,7 +138,7 @@ class UpdateCommandTest extends TestCase
             $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(PHP_EOL, $scripts), $content);
+            $this->assertContains(implode(" && ", $scripts), $content);
         }
     }
 


### PR DESCRIPTION
Concat hooks with && to execute following command only if the previous command was successful.

For example if you have two hooks, first one to check your syntax and second one to check your code quality, if syntax fails right now the second one it's going to be executed, with this change if any of the hooks fails, execution stops.

Steps to reproduce:

Add the following hook configuration
```bash
"pre-commit": [
    "echo execution-error;`exit 1`",
    "echo first hook;"
],
```

If you execute `./cghooks pre-commit` output shows:

```bash
execution-error
first hook
```

And with the fix the output will be:

```
execution-error
```