### PR TITLE
Stop hook execution when sequence of commands fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,29 @@ All commands have global support (besides testing the hooks. Still requires bein
 
 ### Optional Configuration
 
+#### Stop on failure
+
+When a hook is a sequence of commands, it can be useful to stop the execution when
+a command fails.
+
+Specify the impacted hooks in the `stop-on-failure` config section.
+
+```json
+{
+    "extra": {
+        "hooks": {
+            "config": {
+                "stop-on-failure": ["pre-push"]
+            },
+            "pre-push": [
+                "php-cs-fixer fix --dry-run --stop-on-violation .",
+                "phpunit"
+            ],
+        }
+    }
+}
+```
+
 #### Shortcut
 
 Add a `cghooks` script to the `scripts` section of your `composer.json` file. That way, commands can be run with `composer cghooks ${command}`. This is ideal if you would rather not edit your system path.

--- a/cghooks
+++ b/cghooks
@@ -30,7 +30,7 @@ $application->add(new RemoveCommand());
 $application->add(new ListCommand());
 
 foreach (Hook::getHooks($dir) as $hook => $script) {
-    $application->add(new HookCommand($hook, $script));
+    $application->add(new HookCommand($hook, $script, $dir));
 }
 
 $application->run();

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -83,7 +83,7 @@ class AddCommand extends Command
         // On windows, the shebang needs to point to bash
         // See: https://github.com/BrainMaestro/composer-git-hooks/issues/7
         $shebang = ($this->windows ? '#!/bin/bash' : '#!/bin/sh') . PHP_EOL . PHP_EOL;
-        $contents = get_hook_contents($contents);
+        $contents = Hook::getHookContents($this->composerDir, $contents, $hook);
         $hookContents = $shebang . $contents . PHP_EOL;
 
         if (! $this->force && $exists) {

--- a/src/Commands/AddCommand.php
+++ b/src/Commands/AddCommand.php
@@ -83,7 +83,8 @@ class AddCommand extends Command
         // On windows, the shebang needs to point to bash
         // See: https://github.com/BrainMaestro/composer-git-hooks/issues/7
         $shebang = ($this->windows ? '#!/bin/bash' : '#!/bin/sh') . PHP_EOL . PHP_EOL;
-        $contents = Hook::getHookContents($this->composerDir, $contents, $hook);
+        $composerDir = $this->global ? $this->dir : getcwd();
+        $contents = Hook::getHookContents($composerDir, $contents, $hook);
         $hookContents = $shebang . $contents . PHP_EOL;
 
         if (! $this->force && $exists) {

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -12,6 +12,7 @@ abstract class Command extends SymfonyCommand
     private $output;
 
     protected $dir;
+    protected $composerDir;
     protected $hooks;
     protected $gitDir;
     protected $lockDir;

--- a/src/Commands/HookCommand.php
+++ b/src/Commands/HookCommand.php
@@ -2,6 +2,7 @@
 
 namespace BrainMaestro\GitHooks\Commands;
 
+use BrainMaestro\GitHooks\Hook;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -10,11 +11,13 @@ class HookCommand extends SymfonyCommand
 {
     private $hook;
     private $contents;
+    private $composerDir;
 
-    public function __construct($hook, $contents)
+    public function __construct($hook, $contents, $composerDir)
     {
         $this->hook     = $hook;
         $this->contents = $contents;
+        $this->composerDir = $composerDir;
         parent::__construct();
     }
 
@@ -29,8 +32,7 @@ class HookCommand extends SymfonyCommand
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $contents = get_hook_contents($this->contents);
-
+        $contents = Hook::getHookContents($this->composerDir, $this->contents, $this->hook);
         $outputMessage = [];
         $returnCode    = 0;
         exec($contents, $outputMessage, $returnCode);

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -2,9 +2,72 @@
 
 namespace BrainMaestro\GitHooks;
 
+use Exception;
+
 class Hook
 {
     const LOCK_FILE = 'cghooks.lock';
+    const CONFIG_SECTIONS = ['stop-on-failure'];
+
+    /**
+     * Return hook contents
+     *
+     * @param string $dir
+     * @param array|string $contents
+     * @param string $hook
+     *
+     * @return string
+     */
+    public static function getHookContents($dir, $contents, $hook)
+    {
+        if (is_array($contents)) {
+            $commandsSequence = self::stopHookOnFailure($dir, $hook);
+            $separator = $commandsSequence ? ' && \\'.PHP_EOL : PHP_EOL;
+            $contents = implode($separator, $contents);
+        }
+
+        return $contents;
+    }
+
+    /**
+     * Get config section of the composer config file.
+     *
+     * @param  string $dir dir where to look for composer.json
+     * @param  string $section config section to fetch in the composer.json
+     *
+     * @return array
+     */
+    public static function getConfig($dir, $section)
+    {
+        if (! in_array($section, self::CONFIG_SECTIONS)) {
+            throw new Exception("Invalid config section [{$section}]. Available sections: ".implode(', ', self::CONFIG_SECTIONS).'.');
+        }
+
+        $composerFile = "{$dir}/composer.json";
+        if (! file_exists($composerFile)) {
+            return [];
+        }
+
+        $contents = file_get_contents($composerFile);
+        $json = json_decode($contents, true);
+        if (! isset($json['extra']['hooks']['config'][$section])) {
+            return [];
+        }
+
+        return $json['extra']['hooks']['config'][$section];
+    }
+
+    /**
+     * Check if the given hook is a sequence of commands.
+     *
+     * @param string $dir
+     * @param string $hook
+     * @return bool
+     */
+    public static function stopHookOnFailure($dir, $hook)
+    {
+        return in_array($hook, self::getConfig($dir, 'stop-on-failure'));
+    }
 
     /**
      * Get scripts section of the composer config file.
@@ -23,7 +86,7 @@ class Hook
     public static function getHooks($dir)
     {
         $composerFile = "{$dir}/composer.json";
-        if (!file_exists($composerFile)) {
+        if (! file_exists($composerFile)) {
             return [];
         }
 

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -57,17 +57,3 @@ if (! function_exists('git_dir')) {
         return realpath($gitDir);
     }
 }
-
-if (! function_exists('get_hook_contents')) {
-    /**
-     * Return hook contents
-     *
-     * @param array|string $contents
-     *
-     * @return string
-     */
-    function get_hook_contents($contents)
-    {
-        return is_array($contents) ? implode(" && \\" . PHP_EOL, $contents) : $contents;
-    }
-}

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -315,7 +315,7 @@ class AddCommandTest extends TestCase
     {
         $hooks = [
             'config' => [
-                'pre-commit',
+                'stop-on-failure' => ['pre-commit'],
             ],
             'pre-commit' => [
                 'echo "pre-commit 1"',

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -303,8 +303,46 @@ class AddCommandTest extends TestCase
             $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(" && \\" . PHP_EOL, $scripts), $content);
+            $this->assertContains(implode(PHP_EOL, $scripts), $content);
         }
+    }
+
+
+    /**
+     * @test
+     */
+    public function it_uses_commands_sequence_for_configured_hooks_only()
+    {
+        $hooks = [
+            'config' => [
+                'pre-commit',
+            ],
+            'pre-commit' => [
+                'echo "pre-commit 1"',
+                'echo "pre-commit 2"',
+                'echo "pre-commit 3"',
+            ],
+            'post-commit' => [
+                'echo "post-commit 1"',
+                'echo "post-commit 2"',
+                'echo "post-commit 3"',
+            ],
+        ];
+        self::createTestComposerFile('.', $hooks);
+
+        $this->commandTester->execute([]);
+
+        $content = file_get_contents(".git/hooks/pre-commit");
+        $expected = 'echo "pre-commit 1" && \\'. PHP_EOL.
+                'echo "pre-commit 2" && \\'. PHP_EOL.
+                'echo "pre-commit 3"';
+        $this->assertContains($expected, $content);
+
+        $content = file_get_contents(".git/hooks/post-commit");
+        $expected = 'echo "post-commit 1"'. PHP_EOL.
+                'echo "post-commit 2"'. PHP_EOL.
+                'echo "post-commit 3"';
+        $this->assertContains($expected, $content);
     }
 
     /**

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -13,7 +13,7 @@ class HookCommandTest extends TestCase
     public function it_tests_hooks_that_exist()
     {
         foreach (self::$hooks as $hook => $script) {
-            $command = new HookCommand($hook, $script);
+            $command = new HookCommand($hook, $script, '.');
             $commandTester = new CommandTester($command);
 
             $commandTester->execute([]);
@@ -33,7 +33,7 @@ class HookCommandTest extends TestCase
             ],
         ];
 
-        $command = new HookCommand('pre-commit', $hook['pre-commit']);
+        $command = new HookCommand('pre-commit', $hook['pre-commit'], '.');
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([]);

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -171,7 +171,7 @@ class UpdateCommandTest extends TestCase
             $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(" && \\" . PHP_EOL, $scripts), $content);
+            $this->assertContains(implode(PHP_EOL, $scripts), $content);
         }
     }
 


### PR DESCRIPTION
Hi,
As discussed in the issue #113, this PR allows to configure a list of hooks that should stopped when a command fails.

Here is an example:
```json
{
    "extra": {
        "hooks": {
            "config": {
                "stop-on-failure": ["pre-push"]
            },
            "pre-push": [
                "php-cs-fixer fix --dry-run --stop-on-violation .",
                "phpunit"
            ],
        }
    }
}
```

I updated the README. I also added some tests but I can't make them work locally.

Thanks