### PR TITLE
Don't show command error if git is not initialized

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -39,6 +39,10 @@ abstract class Command extends SymfonyCommand
                 $this->global_dir_fallback();
             }
         }
+        if($this->gitDir === false) {
+            $output->writeln('Git is not initialized. Skip setting hooks...');
+            return 0;
+        }
         $this->lockFile = (null !== $this->lockDir ? ($this->lockDir . '/') : '') . Hook::LOCK_FILE;
 
         $dir = $this->global ? $this->dir : getcwd();

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -48,7 +48,7 @@ if (! function_exists('git_dir')) {
      */
     function git_dir()
     {
-        // Don't show command error if git not initialized
+        // Don't show command error if git is not initialized
         $errorToDevNull = is_windows() ? '' : ' 2>/dev/null';
 
         $gitDir = trim(shell_exec('git rev-parse --git-common-dir'.$errorToDevNull));

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -44,6 +44,7 @@ if (! function_exists('git_dir')) {
     /**
      * Resolve absolute git dir which will serve as the default git dir
      * if one is not provided by the user.
+     * @return string|false
      */
     function git_dir()
     {
@@ -54,9 +55,9 @@ if (! function_exists('git_dir')) {
         if ($gitDir === '' || $gitDir === '--git-common-dir') {
             // the version of git does not support `--git-common-dir`
             // we fallback to `--git-dir` which and lose worktree support
-            return realpath(trim(shell_exec('git rev-parse --git-dir'.$errorToDevNull)));
+            $gitDir = trim(shell_exec('git rev-parse --git-dir'.$errorToDevNull));
         }
 
-        return realpath($gitDir);
+        return $gitDir === '' ? false : realpath($gitDir);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -47,11 +47,14 @@ if (! function_exists('git_dir')) {
      */
     function git_dir()
     {
-        $gitDir = trim(shell_exec('git rev-parse --git-common-dir'));
-        if ($gitDir === null || $gitDir === '' || $gitDir === '--git-common-dir') {
+        // Don't show command error if git not initialized
+        $errorToDevNull = is_windows() ? '' : ' 2>/dev/null';
+
+        $gitDir = trim(shell_exec('git rev-parse --git-common-dir'.$errorToDevNull));
+        if ($gitDir === '' || $gitDir === '--git-common-dir') {
             // the version of git does not support `--git-common-dir`
             // we fallback to `--git-dir` which and lose worktree support
-            return realpath(trim(shell_exec('git rev-parse --git-dir')));
+            return realpath(trim(shell_exec('git rev-parse --git-dir'.$errorToDevNull)));
         }
 
         return realpath($gitDir);


### PR DESCRIPTION
I have an error if git is not initialized. This is not user friendly error.
![image](https://user-images.githubusercontent.com/49632507/136557187-df5a19b5-6938-454f-be3a-5a983f428dde.png)

I made the script execution stop if the directory is not found.
![image](https://user-images.githubusercontent.com/49632507/136557413-8c8e5df3-0105-4a92-bcc0-d9ca00646313.png)
