### PR TITLE
Update to Symfony 6, PHP-CS-Fixer 3 and PHPUnit 9.5

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['7.3', '7.4']
+        php: ['8.0', '8.1']
 
     steps:
     - name: Checkout

--- a/composer.json
+++ b/composer.json
@@ -16,12 +16,12 @@
         }
     ],
     "require": {
-        "php": ">=7.3",
-        "symfony/console": "^5.0"
+        "php": "^8.0",
+        "symfony/console": "^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
-        "friendsofphp/php-cs-fixer": "^2.18",
+        "phpunit/phpunit": "^9.5",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "ext-json": "*"
     },
     "autoload": {

--- a/src/Hook.php
+++ b/src/Hook.php
@@ -6,8 +6,8 @@ use Exception;
 
 class Hook
 {
-    const LOCK_FILE = 'cghooks.lock';
-    const CONFIG_SECTIONS = ['custom-hooks', 'stop-on-failure'];
+    public const LOCK_FILE = 'cghooks.lock';
+    public const CONFIG_SECTIONS = ['custom-hooks', 'stop-on-failure'];
 
     /**
      * Return hook contents

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -36,7 +36,7 @@ if (! function_exists('global_hook_dir')) {
      */
     function global_hook_dir()
     {
-        return trim(shell_exec('git config --global core.hooksPath'));
+        return trim((string) shell_exec('git config --global core.hooksPath'));
     }
 }
 

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -24,7 +24,7 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -41,7 +41,7 @@ class AddCommandTest extends TestCase
 
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             "No hooks were added. Try updating",
             $this->commandTester->getDisplay()
         );
@@ -64,11 +64,11 @@ class AddCommandTest extends TestCase
 
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'Added pre-flow-feature-start hook',
             $this->commandTester->getDisplay()
         );
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             'Added pre-flow-hotfix-start hook',
             $this->commandTester->getDisplay()
         );
@@ -86,7 +86,7 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
             $this->assertNotFalse(strpos($content, "#!/bin/bash"));
@@ -103,10 +103,10 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("{$hook} already exists", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("{$hook} already exists", $this->commandTester->getDisplay());
         }
 
-        $this->assertContains('No hooks were added. Try updating', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('No hooks were added. Try updating', $this->commandTester->getDisplay());
     }
 
     /**
@@ -124,9 +124,9 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("{$hook} is up to date", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("{$hook} is up to date", $this->commandTester->getDisplay());
         }
-        $this->assertContains('All hooks are up to date', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('All hooks are up to date', $this->commandTester->getDisplay());
 
         self::$hooks = $originalHooks;
     }
@@ -140,7 +140,7 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute(['--force' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -152,7 +152,7 @@ class AddCommandTest extends TestCase
         $currentDir = realpath(getcwd());
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Created ' . $currentDir . '/' . Hook::LOCK_FILE . ' file', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Created ' . $currentDir . '/' . Hook::LOCK_FILE . ' file', $this->commandTester->getDisplay());
         $this->assertFileExists(Hook::LOCK_FILE);
         $this->assertEquals(json_encode(array_keys(self::$hooks)), file_get_contents(Hook::LOCK_FILE));
     }
@@ -165,12 +165,14 @@ class AddCommandTest extends TestCase
     {
         $lockDir = 'lock-dir';
         $currentDir = realpath(getcwd());
-        mkdir('../' . $lockDir);
+        if (!file_exists($lockDir)) {
+            mkdir('../' . $lockDir);
+        }
 
         $hookFile = $currentDir . '/../' . $lockDir . '/' . Hook::LOCK_FILE;
         $this->commandTester->execute(['--lock-dir' => dirname($hookFile)], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Created '. $hookFile . ' file', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Created '. $hookFile . ' file', $this->commandTester->getDisplay());
         $this->assertFileExists($hookFile);
         $this->assertEquals(json_encode(array_keys(self::$hooks)), file_get_contents($hookFile));
         self::rmdir('../' . $lockDir);
@@ -184,8 +186,8 @@ class AddCommandTest extends TestCase
         $currentDir = realpath(getcwd());
         $this->commandTester->execute(['--no-lock' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Skipped creating a ' . Hook::LOCK_FILE . ' file', $this->commandTester->getDisplay());
-        $this->assertFileNotExists(Hook::LOCK_FILE);
+        $this->assertStringContainsString('Skipped creating a ' . Hook::LOCK_FILE . ' file', $this->commandTester->getDisplay());
+        $this->assertFileDoesNotExist(Hook::LOCK_FILE);
     }
 
     /**
@@ -196,7 +198,7 @@ class AddCommandTest extends TestCase
         $currentDir = realpath(getcwd());
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Skipped adding ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Skipped adding ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
         $this->assertFalse(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE));
     }
 
@@ -207,7 +209,7 @@ class AddCommandTest extends TestCase
     {
         $this->commandTester->execute(['--ignore-lock' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('Added ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('Added ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
@@ -219,7 +221,7 @@ class AddCommandTest extends TestCase
         file_put_contents('.gitignore', Hook::LOCK_FILE . PHP_EOL, FILE_APPEND);
         $this->commandTester->execute(['--ignore-lock' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertNotContains('Added ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
+        $this->assertStringNotContainsString('Added ' . Hook::LOCK_FILE . ' to .gitignore', $this->commandTester->getDisplay());
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
@@ -248,9 +250,9 @@ class AddCommandTest extends TestCase
         self::removeTestComposerFile(); // so that there will be no hooks to add
         $this->commandTester->execute([]);
 
-        $this->assertContains('No hooks were added. Try updating', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('No hooks were added. Try updating', $this->commandTester->getDisplay());
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertFileNotExists(".git/hooks/{$hook}");
+            $this->assertFileDoesNotExist(".git/hooks/{$hook}");
         }
     }
 
@@ -278,7 +280,7 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute(['--force-win' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
             $this->assertNotFalse(strpos($content, "#!/bin/bash"));
@@ -303,10 +305,10 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach ($hooks as $hook => $scripts) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(PHP_EOL, $scripts), $content);
+            $this->assertStringContainsString(implode(PHP_EOL, $scripts), $content);
         }
     }
 
@@ -339,13 +341,13 @@ class AddCommandTest extends TestCase
         $expected = 'echo "pre-commit 1" && \\'. PHP_EOL.
                 'echo "pre-commit 2" && \\'. PHP_EOL.
                 'echo "pre-commit 3"';
-        $this->assertContains($expected, $content);
+        $this->assertStringContainsString($expected, $content);
 
         $content = file_get_contents(".git/hooks/post-commit");
         $expected = 'echo "post-commit 1"'. PHP_EOL.
                 'echo "post-commit 2"'. PHP_EOL.
                 'echo "post-commit 3"';
-        $this->assertContains($expected, $content);
+        $this->assertStringContainsString($expected, $content);
     }
 
     /**
@@ -364,16 +366,16 @@ class AddCommandTest extends TestCase
         );
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
             $this->assertFileExists("{$hookDir}/{$hook}");
         }
 
         $hookDir = realpath("{$gitDir}/hooks");
-        $this->assertContains(
+        $this->assertStringContainsString(
             'About to modify global git hook path. There was no previous value',
             $this->commandTester->getDisplay()
         );
-        $this->assertContains("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
@@ -395,16 +397,16 @@ class AddCommandTest extends TestCase
         );
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
             $this->assertFileExists("{$hookDir}/{$hook}");
         }
 
         $hookDir = realpath("{$gitDir}/hooks");
-        $this->assertContains(
+        $this->assertStringContainsString(
             "About to modify global git hook path. Previous value was {$previousHookDir}",
             $this->commandTester->getDisplay()
         );
-        $this->assertContains("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
@@ -426,15 +428,15 @@ class AddCommandTest extends TestCase
         );
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
             $this->assertFileExists("{$hookDir}/{$hook}");
         }
 
-        $this->assertNotContains(
+        $this->assertStringNotContainsString(
             "About to modify global git hook path. Previous value was {$hookDir}",
             $this->commandTester->getDisplay()
         );
-        $this->assertNotContains("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
+        $this->assertStringNotContainsString("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
@@ -454,21 +456,21 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
             $this->assertFileExists("{$hookDir}/{$hook}");
         }
 
         $gitDir = realpath('test-global-composer-home-dir');
         $hookDir = "{$gitDir}/hooks";
-        $this->assertContains(
+        $this->assertStringContainsString(
             "No global git hook path was provided. Falling back to COMPOSER_HOME {$gitDir}",
             $this->commandTester->getDisplay()
         );
-        $this->assertContains(
+        $this->assertStringContainsString(
             "About to modify global git hook path. There was no previous value",
             $this->commandTester->getDisplay()
         );
-        $this->assertContains("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Global git hook path set to {$hookDir}", $this->commandTester->getDisplay());
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
@@ -484,10 +486,10 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertNotContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringNotContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You did not specify a git directory to use',
             $this->commandTester->getDisplay()
         );
@@ -507,8 +509,8 @@ class AddCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
-            $this->assertFileNotExists(".git/hooks/{$hook}");
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertFileDoesNotExist(".git/hooks/{$hook}");
             $this->assertFileExists("{$currentDir}/.git/hooks/{$hook}");
         }
 

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -11,6 +11,6 @@ class HelpersTest extends PHPUnitTestCase
      */
     public function it_checks_os()
     {
-        $this->assertInternalType('boolean', is_windows());
+        $this->assertIsBool(is_windows());
     }
 }

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -17,7 +17,7 @@ class HookCommandTest extends TestCase
             $commandTester = new CommandTester($command);
 
             $commandTester->execute([]);
-            $this->assertContains(str_replace('echo ', '', $script), $commandTester->getDisplay());
+            $this->assertStringContainsString(str_replace('echo ', '', $script), $commandTester->getDisplay());
         }
     }
 
@@ -37,7 +37,7 @@ class HookCommandTest extends TestCase
         $commandTester = new CommandTester($command);
 
         $commandTester->execute([]);
-        $this->assertContains('execution-error', $commandTester->getDisplay());
-        $this->assertNotContains('before-commit', $commandTester->getDisplay());
+        $this->assertStringContainsString('execution-error', $commandTester->getDisplay());
+        $this->assertStringNotContainsString('before-commit', $commandTester->getDisplay());
     }
 }

--- a/tests/ListCommandTest.php
+++ b/tests/ListCommandTest.php
@@ -25,7 +25,7 @@ class ListCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains($hook, $this->commandTester->getDisplay());
+            $this->assertStringContainsString($hook, $this->commandTester->getDisplay());
         }
     }
 
@@ -47,7 +47,7 @@ class ListCommandTest extends TestCase
 
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
 
-        $this->assertContains('pre-flow-feature-start', $this->commandTester->getDisplay());
+        $this->assertStringContainsString('pre-flow-feature-start', $this->commandTester->getDisplay());
     }
 
     /**
@@ -61,7 +61,7 @@ class ListCommandTest extends TestCase
         $this->commandTester->execute(['--git-dir' => $gitDir]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains($hook, $this->commandTester->getDisplay());
+            $this->assertStringContainsString($hook, $this->commandTester->getDisplay());
         }
     }
 
@@ -81,7 +81,7 @@ class ListCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains($hook, $this->commandTester->getDisplay());
+            $this->assertStringContainsString($hook, $this->commandTester->getDisplay());
         }
     }
 }

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -29,7 +29,7 @@ class RemoveCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -50,7 +50,7 @@ class RemoveCommandTest extends TestCase
 
         $this->commandTester->execute([]);
 
-        $this->assertContains("Removed pre-flow-feature-start hook", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Removed pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
     /**
@@ -65,7 +65,7 @@ class RemoveCommandTest extends TestCase
             $this->assertEquals(0, $return);
 
             $this->commandTester->execute(['hooks' => [$hook]]);
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
 
             $contents = file_get_contents('.gitignore');
             $return = strpos($contents, Hook::LOCK_FILE);
@@ -80,7 +80,7 @@ class RemoveCommandTest extends TestCase
     {
         foreach (array_keys(self::$hooks) as $hook) {
             $this->commandTester->execute(['hooks' => [$hook]]);
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -93,7 +93,7 @@ class RemoveCommandTest extends TestCase
         unlink(Hook::LOCK_FILE);
 
         $this->commandTester->execute(['hooks' => [$hook]], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
-        $this->assertContains(
+        $this->assertStringContainsString(
             "Skipped {$hook} hook - not present in lock file",
             $this->commandTester->getDisplay()
         );
@@ -109,7 +109,7 @@ class RemoveCommandTest extends TestCase
         touch(".git/hooks/{$hook}");
 
         $this->commandTester->execute(['hooks' => [$hook], '--force' => true]);
-        $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
     }
 
     /**
@@ -124,7 +124,7 @@ class RemoveCommandTest extends TestCase
 
         $this->commandTester->execute(['--git-dir' => $gitDir]);
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
         }
 
         $this->assertTrue(self::isDirEmpty("{$gitDir}/hooks"));
@@ -147,7 +147,7 @@ class RemoveCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -158,13 +158,15 @@ class RemoveCommandTest extends TestCase
     public function it_removes_git_hooks_with_lock_dir()
     {
         $lockDir = realpath(getcwd()) . '/../lock-dir';
-        mkdir($lockDir);
+        if (!file_exists($lockDir)) {
+            mkdir($lockDir);
+        }
         $hookFile = $lockDir . '/' . Hook::LOCK_FILE;
         self::createHooks('.git', true, $lockDir);
 
         $this->commandTester->execute(['--lock-dir' => dirname($hookFile)]);
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Removed {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
         }
         self::rmdir($lockDir);
     }

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -27,7 +27,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Added {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Added {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -40,7 +40,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -60,7 +60,7 @@ class UpdateCommandTest extends TestCase
 
         $this->commandTester->execute([]);
 
-        $this->assertContains("Added pre-flow-feature-start hook", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Added pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
     /**
@@ -80,7 +80,7 @@ class UpdateCommandTest extends TestCase
 
         $this->commandTester->execute([]);
 
-        $this->assertContains("Updated pre-flow-feature-start hook", $this->commandTester->getDisplay());
+        $this->assertStringContainsString("Updated pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
     /**
@@ -96,7 +96,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
             $this->assertNotFalse(strpos($content, "#!/bin/bash"));
@@ -148,7 +148,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute(['--force-win' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
             $this->assertNotFalse(strpos($content, "#!/bin/bash"));
@@ -174,10 +174,10 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute([]);
 
         foreach ($hooks as $hook => $scripts) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
 
             $content = file_get_contents(".git/hooks/" . $hook);
-            $this->assertContains(implode(PHP_EOL, $scripts), $content);
+            $this->assertStringContainsString(implode(PHP_EOL, $scripts), $content);
         }
     }
 
@@ -197,7 +197,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
     }
 
@@ -208,7 +208,9 @@ class UpdateCommandTest extends TestCase
     public function it_updates_git_hooks_with_lock_dir()
     {
         $lockDir = realpath(getcwd()) . '/../lock-dir';
-        mkdir($lockDir);
+        if (!file_exists($lockDir)) {
+            mkdir($lockDir);
+        }
         $hookFile = $lockDir . '/' . Hook::LOCK_FILE;
 
         self::createHooks('.git', true, $lockDir);
@@ -216,7 +218,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute(['--lock-dir' => dirname($hookFile)]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
 
         self::rmdir($lockDir);
@@ -234,10 +236,10 @@ class UpdateCommandTest extends TestCase
         $this->commandTester->execute(['--global' => true]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertNotContains("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertStringNotContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
         }
 
-        $this->assertContains(
+        $this->assertStringContainsString(
             'You need to run the add command globally first before you try to update',
             $this->commandTester->getDisplay()
         );
@@ -251,15 +253,17 @@ class UpdateCommandTest extends TestCase
         self::createHooks();
         $currentDir = realpath(getcwd());
         shell_exec('git branch develop');
-        mkdir('../worktree-test');
+        if (!file_exists($path = '../worktree-test')) {
+            mkdir($path);
+        }
         shell_exec('git worktree add -b test ../worktree-test develop');
         chdir('../worktree-test');
 
         $this->commandTester->execute([]);
 
         foreach (array_keys(self::$hooks) as $hook) {
-            $this->assertContains("Updated {$hook} hook", $this->commandTester->getDisplay());
-            $this->assertFileNotExists(".git/hooks/{$hook}");
+            $this->assertStringContainsString("Updated {$hook} hook", $this->commandTester->getDisplay());
+            $this->assertFileDoesNotExist(".git/hooks/{$hook}");
             $this->assertFileExists("{$currentDir}/.git/hooks/{$hook}");
         }
 


### PR DESCRIPTION
Closes #123 

### Changed:
- Updated to Symfony\Console `^6.0`
- Updated to PHP-CS-Fixer `^3.0`
- Updated to PHPUnit `^9.5`
    - Rename `assertContains` to `assertStringContainsString`
    - Rename `assertNotContains ` to `assertStringNotContainsString`
    - Rename `assertFileNotExists' to 'assertFileDoesNotExist'
- Updated to PHP `^8.0`
- Updated GitHub Actions workflows
- Make constants public (Hook.php)
- Cast `shell_exec` output to string (src/helpers.php) because `trim` required a `string` and not `string|ƒalse|null`

### Added
- Added `file_exists` check before create a directory

EDIT:
For these wanting to try out these changes you can do the following to your composer.json:
```json
{
    "repositories": [
        {
            "type": "git",
            "url": "https://github.com/Jubeki/composer-git-hooks"
        }
    ],
    "require-dev": {
        "brainmaestro/composer-git-hooks": "dev-prepare-for-symfony-6"
    },
    "minimum-stability": "dev",
    "prefer-stable": true
}
```