### PR TITLE
Allow symfony/console 7 and add tests for php 8.2 and 8.3 with phpunit range

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.0', '8.1']
+        php: ['8.0', '8.1', '8.2', '8.3']
 
     steps:
     - name: Checkout

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ cghooks-temp-*
 .php_cs.cache
 phpunit.xml
 cghooks.lock
+composer.lock
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -59,9 +59,9 @@
                 "composer test",
                 "appver=$(grep -o -E '[0-9]+\\.[0-9]+\\.[0-9]+(-alpha\\.[0-9]+)?' cghooks)",
                 "tag=$(git tag | tail -n 1)",
-                "if [ \"$tag\" != \"v$appver\" ]; then",
-                "echo \"The most recent tag $tag does not match the application version $appver\\n\"",
                 "tag=${tag#v}",
+                "if [ \"$tag\" != \"$appver\" ]; then",
+                "echo \"The most recent tag $tag does not match the application version $appver\\n\"",
                 "sed -i -E \"s/$appver/$tag/\" cghooks",
                 "exit 1",
                 "fi"

--- a/composer.json
+++ b/composer.json
@@ -16,11 +16,11 @@
         }
     ],
     "require": {
-        "php": "^8.0|^8.1",
-        "symfony/console": "^5.0|^6.0"
+        "php": "^8.0",
+        "symfony/console": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^11",
         "friendsofphp/php-cs-fixer": "^3.0",
         "ext-json": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
             "pre-commit": "composer check-style",
             "pre-push": [
                 "composer test",
-                "appver=$(grep -o -P '\\d+\\.\\d+\\.\\d+(-alpha\\.\\d+)?' cghooks)",
+                "appver=$(grep -o -E '[0-9]+\\.[0-9]+\\.[0-9]+(-alpha\\.[0-9]+)?' cghooks)",
                 "tag=$(git tag | tail -n 1)",
                 "if [ \"$tag\" != \"v$appver\" ]; then",
                 "echo \"The most recent tag $tag does not match the application version $appver\\n\"",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/console": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^9|^10|^11",
         "friendsofphp/php-cs-fixer": "^3.0",
         "ext-json": "*"
     },
@@ -57,7 +57,7 @@
             "pre-commit": "composer check-style",
             "pre-push": [
                 "composer test",
-                "appver=$(grep -o -E '\\d.\\d.\\d(-alpha.\\d)?' cghooks)",
+                "appver=$(grep -o -P '\\d+\\.\\d+\\.\\d+(-alpha\\.\\d+)?' cghooks)",
                 "tag=$(git tag | tail -n 1)",
                 "if [ \"$tag\" != \"v$appver\" ]; then",
                 "echo \"The most recent tag $tag does not match the application version $appver\\n\"",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,16 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         bootstrap="vendor/autoload.php"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-	 stopOnFailure="false">
-    <testsuites>
-        <testsuite name="Application Test Suite">
-            <directory>./tests/</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.2/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Application Test Suite">
+      <directory>./tests/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -23,7 +23,7 @@ abstract class Command extends SymfonyCommand
 
     abstract protected function command();
 
-    final protected function execute(InputInterface $input, OutputInterface $output)
+    final protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = $output;
         $this->gitDir = $input->getOption('git-dir') ?: git_dir();

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -41,7 +41,7 @@ abstract class Command extends SymfonyCommand
         }
         if ($this->gitDir === false) {
             $output->writeln('Git is not initialized. Skip setting hooks...');
-            return 0;
+            return SymfonyCommand::SUCCESS;
         }
         $this->lockFile = (null !== $this->lockDir ? ($this->lockDir . '/') : '') . Hook::LOCK_FILE;
 
@@ -52,7 +52,7 @@ abstract class Command extends SymfonyCommand
         $this->init($input);
         $this->command();
 
-        return 0;
+        return SymfonyCommand::SUCCESS;
     }
 
     protected function global_dir_fallback()

--- a/src/Commands/HookCommand.php
+++ b/src/Commands/HookCommand.php
@@ -30,7 +30,7 @@ class HookCommand extends SymfonyCommand
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $contents = Hook::getHookContents($this->composerDir, $this->contents, $this->hook);
         $outputMessage = [];

--- a/src/Commands/HookCommand.php
+++ b/src/Commands/HookCommand.php
@@ -34,7 +34,7 @@ class HookCommand extends SymfonyCommand
     {
         $contents = Hook::getHookContents($this->composerDir, $this->contents, $this->hook);
         $outputMessage = [];
-        $returnCode    = 0;
+        $returnCode    = SymfonyCommand::SUCCESS;
         exec($contents, $outputMessage, $returnCode);
 
         $output->writeln(implode(PHP_EOL, $outputMessage));

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -4,6 +4,7 @@ namespace BrainMaestro\GitHooks\Tests;
 
 use BrainMaestro\GitHooks\Commands\AddCommand;
 use BrainMaestro\GitHooks\Hook;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\OutputInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -17,6 +18,7 @@ class AddCommandTest extends TestCase
         $this->commandTester = new CommandTester(new AddCommand());
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_hooks_that_do_not_already_exist()
     {
@@ -27,6 +29,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_doesnt_allow_to_add_custom_hooks_by_default()
     {
@@ -44,6 +47,7 @@ class AddCommandTest extends TestCase
         );
     }
 
+    /** @test  */
     #[Test]
     public function it_allows_to_add_custom_hooks_specified_in_config_section()
     {
@@ -69,6 +73,7 @@ class AddCommandTest extends TestCase
         );
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_shebang_to_hooks_on_windows()
     {
@@ -87,6 +92,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_add_hooks_that_already_exist()
     {
@@ -100,6 +106,7 @@ class AddCommandTest extends TestCase
         $this->assertStringContainsString('No hooks were added. Try updating', $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_detects_existing_correct_hooks()
     {
@@ -120,6 +127,7 @@ class AddCommandTest extends TestCase
         self::$hooks = $originalHooks;
     }
 
+    /** @test  */
     #[Test]
     public function it_overrides_hooks_that_already_exist()
     {
@@ -131,6 +139,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_correctly_creates_the_hook_lock_file()
     {
@@ -146,6 +155,8 @@ class AddCommandTest extends TestCase
      * @test
      * @group lock-dir
      */
+    #[Test]
+    #[Group('lock-dir')]
     public function it_correctly_creates_the_hook_lock_file_in_lock_dir()
     {
         $lockDir = 'lock-dir';
@@ -163,6 +174,7 @@ class AddCommandTest extends TestCase
         self::rmdir('../' . $lockDir);
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_create_the_hook_lock_file_if_the_no_lock_option_is_passed()
     {
@@ -173,6 +185,7 @@ class AddCommandTest extends TestCase
         $this->assertFileDoesNotExist(Hook::LOCK_FILE);
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_ignore_the_hook_lock_file()
     {
@@ -183,6 +196,7 @@ class AddCommandTest extends TestCase
         $this->assertFalse(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE));
     }
 
+    /** @test  */
     #[Test]
     public function it_ignores_the_hook_lock_file_if_the_ignore_lock_option_is_passed()
     {
@@ -192,6 +206,7 @@ class AddCommandTest extends TestCase
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_ignore_the_hook_lock_file_if_it_is_already_ignored()
     {
@@ -202,6 +217,7 @@ class AddCommandTest extends TestCase
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
+    /** @test  */
     #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
@@ -217,6 +233,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_create_a_lock_file_when_no_hooks_were_added()
     {
@@ -229,6 +246,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_create_git_hooks_path_when_hooks_dir_not_exists()
     {
@@ -243,6 +261,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
     {
@@ -257,6 +276,7 @@ class AddCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_handles_commands_defined_in_an_array()
     {
@@ -280,6 +300,7 @@ class AddCommandTest extends TestCase
     }
 
 
+    /** @test  */
     #[Test]
     public function it_uses_commands_sequence_for_configured_hooks_only()
     {
@@ -315,6 +336,7 @@ class AddCommandTest extends TestCase
         $this->assertStringContainsString($expected, $content);
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_global_git_hooks()
     {
@@ -342,6 +364,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_global_git_hooks_and_shows_previous_global_dir()
     {
@@ -371,6 +394,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_global_git_hooks_and_does_not_change_global_dir_if_it_matches_new_value()
     {
@@ -399,6 +423,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
+    /** @test  */
     #[Test]
     public function it_falls_back_to_composer_home_if_no_global_hook_dir_is_provided()
     {
@@ -431,6 +456,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
+    /** @test  */
     #[Test]
     public function it_fails_if_global_hook_dir_is_missing()
     {
@@ -450,6 +476,7 @@ class AddCommandTest extends TestCase
         );
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_hooks_correctly_in_a_git_worktree()
     {

--- a/tests/AddCommandTest.php
+++ b/tests/AddCommandTest.php
@@ -6,6 +6,7 @@ use BrainMaestro\GitHooks\Commands\AddCommand;
 use BrainMaestro\GitHooks\Hook;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\OutputInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class AddCommandTest extends TestCase
 {
@@ -16,9 +17,7 @@ class AddCommandTest extends TestCase
         $this->commandTester = new CommandTester(new AddCommand());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_hooks_that_do_not_already_exist()
     {
         $this->commandTester->execute([]);
@@ -28,9 +27,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_doesnt_allow_to_add_custom_hooks_by_default()
     {
         $customHooks = [
@@ -47,9 +44,7 @@ class AddCommandTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_allows_to_add_custom_hooks_specified_in_config_section()
     {
         $customHooks = [
@@ -74,9 +69,7 @@ class AddCommandTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_shebang_to_hooks_on_windows()
     {
         if (! is_windows()) {
@@ -94,9 +87,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_add_hooks_that_already_exist()
     {
         self::createHooks();
@@ -109,9 +100,7 @@ class AddCommandTest extends TestCase
         $this->assertStringContainsString('No hooks were added. Try updating', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_detects_existing_correct_hooks()
     {
         $originalHooks = self::$hooks;
@@ -131,9 +120,7 @@ class AddCommandTest extends TestCase
         self::$hooks = $originalHooks;
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_overrides_hooks_that_already_exist()
     {
         self::createHooks();
@@ -144,9 +131,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_correctly_creates_the_hook_lock_file()
     {
         $currentDir = realpath(getcwd());
@@ -178,9 +163,7 @@ class AddCommandTest extends TestCase
         self::rmdir('../' . $lockDir);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_create_the_hook_lock_file_if_the_no_lock_option_is_passed()
     {
         $currentDir = realpath(getcwd());
@@ -190,9 +173,7 @@ class AddCommandTest extends TestCase
         $this->assertFileDoesNotExist(Hook::LOCK_FILE);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_ignore_the_hook_lock_file()
     {
         $currentDir = realpath(getcwd());
@@ -202,9 +183,7 @@ class AddCommandTest extends TestCase
         $this->assertFalse(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_ignores_the_hook_lock_file_if_the_ignore_lock_option_is_passed()
     {
         $this->commandTester->execute(['--ignore-lock' => true], ['verbosity' => OutputInterface::VERBOSITY_VERBOSE]);
@@ -213,9 +192,7 @@ class AddCommandTest extends TestCase
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_ignore_the_hook_lock_file_if_it_is_already_ignored()
     {
         file_put_contents('.gitignore', Hook::LOCK_FILE . PHP_EOL, FILE_APPEND);
@@ -225,9 +202,7 @@ class AddCommandTest extends TestCase
         $this->assertTrue(strpos(file_get_contents('.gitignore'), Hook::LOCK_FILE) !== false);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
         $gitDir = 'test-git-dir';
@@ -242,9 +217,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_create_a_lock_file_when_no_hooks_were_added()
     {
         self::removeTestComposerFile(); // so that there will be no hooks to add
@@ -256,9 +229,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_create_git_hooks_path_when_hooks_dir_not_exists()
     {
         $gitDir = 'test-git-dir';
@@ -272,9 +243,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
     {
         $this->commandTester->execute(['--force-win' => true]);
@@ -288,9 +257,7 @@ class AddCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_handles_commands_defined_in_an_array()
     {
         $hooks = [
@@ -313,9 +280,7 @@ class AddCommandTest extends TestCase
     }
 
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_commands_sequence_for_configured_hooks_only()
     {
         $hooks = [
@@ -350,9 +315,7 @@ class AddCommandTest extends TestCase
         $this->assertStringContainsString($expected, $content);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_global_git_hooks()
     {
         $gitDir = 'test-global-git-dir';
@@ -379,9 +342,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_global_git_hooks_and_shows_previous_global_dir()
     {
         $gitDir = 'test-global-git-dir';
@@ -410,9 +371,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_global_git_hooks_and_does_not_change_global_dir_if_it_matches_new_value()
     {
         $gitDir = 'test-global-git-dir';
@@ -440,9 +399,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_falls_back_to_composer_home_if_no_global_hook_dir_is_provided()
     {
         $gitDir = 'test-global-composer-home-dir';
@@ -474,9 +431,7 @@ class AddCommandTest extends TestCase
         $this->assertEquals($hookDir, global_hook_dir());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fails_if_global_hook_dir_is_missing()
     {
         putenv('COMPOSER_HOME=');
@@ -495,9 +450,7 @@ class AddCommandTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_hooks_correctly_in_a_git_worktree()
     {
         $currentDir = realpath(getcwd());

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -3,12 +3,11 @@
 namespace BrainMaestro\GitHooks\Tests;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class HelpersTest extends PHPUnitTestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_checks_os()
     {
         $this->assertIsBool(is_windows());

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\Attributes\Test;
 
 class HelpersTest extends PHPUnitTestCase
 {
+    /** @test  */
     #[Test]
     public function it_checks_os()
     {

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\Test;
 
 class HookCommandTest extends TestCase
 {
+    /** @test  */
     #[Test]
     public function it_tests_hooks_that_exist()
     {
@@ -20,6 +21,7 @@ class HookCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_terminates_if_previous_hook_fails()
     {

--- a/tests/HookCommandTest.php
+++ b/tests/HookCommandTest.php
@@ -4,12 +4,11 @@ namespace BrainMaestro\GitHooks\Tests;
 
 use BrainMaestro\GitHooks\Commands\HookCommand;
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\Attributes\Test;
 
 class HookCommandTest extends TestCase
 {
-    /**
-     * @test
-     */
+    #[Test]
     public function it_tests_hooks_that_exist()
     {
         foreach (self::$hooks as $hook => $script) {
@@ -21,9 +20,7 @@ class HookCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_terminates_if_previous_hook_fails()
     {
         $hook = [

--- a/tests/ListCommandTest.php
+++ b/tests/ListCommandTest.php
@@ -5,6 +5,7 @@ namespace BrainMaestro\GitHooks\Tests;
 use BrainMaestro\GitHooks\Commands\ListCommand;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\Attributes\Test;
 
 class ListCommandTest extends TestCase
 {
@@ -16,9 +17,7 @@ class ListCommandTest extends TestCase
         $this->commandTester = new CommandTester(new ListCommand());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_lists_hooks_that_exist()
     {
         self::createHooks();
@@ -29,9 +28,7 @@ class ListCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_lists_custom_hooks_that_exist()
     {
         $customHooks = [
@@ -50,9 +47,7 @@ class ListCommandTest extends TestCase
         $this->assertStringContainsString('pre-flow-feature-start', $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
         $gitDir = 'test-git-dir';
@@ -65,9 +60,7 @@ class ListCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_lists_global_git_hooks()
     {
         $gitDir = 'test-global-git-dir';

--- a/tests/ListCommandTest.php
+++ b/tests/ListCommandTest.php
@@ -17,6 +17,7 @@ class ListCommandTest extends TestCase
         $this->commandTester = new CommandTester(new ListCommand());
     }
 
+    /** @test  */
     #[Test]
     public function it_lists_hooks_that_exist()
     {
@@ -28,6 +29,7 @@ class ListCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_lists_custom_hooks_that_exist()
     {
@@ -47,6 +49,7 @@ class ListCommandTest extends TestCase
         $this->assertStringContainsString('pre-flow-feature-start', $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
@@ -60,6 +63,7 @@ class ListCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_lists_global_git_hooks()
     {

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -4,6 +4,7 @@ namespace BrainMaestro\GitHooks\Tests;
 
 use BrainMaestro\GitHooks\Commands\RemoveCommand;
 use BrainMaestro\GitHooks\Hook;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\OutputInterface;
 use PHPUnit\Framework\Attributes\Test;
@@ -11,6 +12,7 @@ use PHPUnit\Framework\Attributes\Test;
 /**
  * @group remove
  */
+#[Group('remove')]
 class RemoveCommandTest extends TestCase
 {
     /** @var CommandTester */
@@ -22,6 +24,7 @@ class RemoveCommandTest extends TestCase
         $this->commandTester = new CommandTester(new RemoveCommand());
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_hooks_that_were_added()
     {
@@ -32,6 +35,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_custom_hooks_that_were_added()
     {
@@ -50,6 +54,7 @@ class RemoveCommandTest extends TestCase
         $this->assertStringContainsString("Removed pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_removed_hooks_from_the_lock_file()
     {
@@ -68,6 +73,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_individual_hooks()
     {
@@ -77,6 +83,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_does_not_remove_hooks_not_present_in_the_lock_file()
     {
@@ -90,6 +97,7 @@ class RemoveCommandTest extends TestCase
         );
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_hooks_not_present_in_the_lock_file_if_forced_to()
     {
@@ -101,6 +109,7 @@ class RemoveCommandTest extends TestCase
         $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
@@ -117,6 +126,7 @@ class RemoveCommandTest extends TestCase
         $this->assertTrue(self::isDirEmpty("{$gitDir}/hooks"));
     }
 
+    /** @test  */
     #[Test]
     public function it_removes_global_git_hooks()
     {
@@ -140,6 +150,8 @@ class RemoveCommandTest extends TestCase
      * @test
      * @group lock-dir
      */
+    #[Test]
+    #[Group('lock-dir')]
     public function it_removes_git_hooks_with_lock_dir()
     {
         $lockDir = realpath(getcwd()) . '/../lock-dir';

--- a/tests/RemoveCommandTest.php
+++ b/tests/RemoveCommandTest.php
@@ -6,6 +6,7 @@ use BrainMaestro\GitHooks\Commands\RemoveCommand;
 use BrainMaestro\GitHooks\Hook;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\Console\Output\OutputInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @group remove
@@ -21,9 +22,7 @@ class RemoveCommandTest extends TestCase
         $this->commandTester = new CommandTester(new RemoveCommand());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_hooks_that_were_added()
     {
         $this->commandTester->execute([]);
@@ -33,9 +32,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_custom_hooks_that_were_added()
     {
         $customHooks = [
@@ -53,9 +50,7 @@ class RemoveCommandTest extends TestCase
         $this->assertStringContainsString("Removed pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_removed_hooks_from_the_lock_file()
     {
         foreach (array_keys(self::$hooks) as $hook) {
@@ -73,9 +68,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_individual_hooks()
     {
         foreach (array_keys(self::$hooks) as $hook) {
@@ -84,9 +77,7 @@ class RemoveCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_does_not_remove_hooks_not_present_in_the_lock_file()
     {
         $hook = 'pre-commit';
@@ -99,9 +90,7 @@ class RemoveCommandTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_hooks_not_present_in_the_lock_file_if_forced_to()
     {
         $hook = 'pre-commit';
@@ -112,9 +101,7 @@ class RemoveCommandTest extends TestCase
         $this->assertStringContainsString("Removed {$hook} hook", $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
         $gitDir = 'test-git-dir';
@@ -130,9 +117,7 @@ class RemoveCommandTest extends TestCase
         $this->assertTrue(self::isDirEmpty("{$gitDir}/hooks"));
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_removes_global_git_hooks()
     {
         $gitDir = 'test-global-git-dir';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,8 +15,6 @@ abstract class TestCase extends PHPUnitTestCase
     private $tempTestDir;
     private $initialGlobalHookDir;
 
-    private $shouldSignGpg;
-
     final public function setUp(): void
     {
         $this->initialGlobalHookDir = global_hook_dir();
@@ -25,8 +23,7 @@ abstract class TestCase extends PHPUnitTestCase
         mkdir($this->tempTestDir);
         chdir($this->tempTestDir);
         shell_exec('git init');
-        $this->shouldSignGpg = shell_exec('git config --global commit.gpgsign false');
-        shell_exec('git config --global commit.gpgsign false');
+        shell_exec('git config commit.gpgsign false');
         shell_exec('git config user.email "cghooks@example.com"');
         shell_exec('git config user.name "Composer Git Hooks"');
 
@@ -39,7 +36,6 @@ abstract class TestCase extends PHPUnitTestCase
 
     final public function tearDown(): void
     {
-        shell_exec('git config --global commit.gpgsign '.$this->shouldSignGpg);
         chdir('..');
         self::rmdir($this->tempTestDir);
         $this->restoreGlobalHookDir();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,6 +15,8 @@ abstract class TestCase extends PHPUnitTestCase
     private $tempTestDir;
     private $initialGlobalHookDir;
 
+    private $shouldSignGpg;
+
     final public function setUp(): void
     {
         $this->initialGlobalHookDir = global_hook_dir();
@@ -23,6 +25,8 @@ abstract class TestCase extends PHPUnitTestCase
         mkdir($this->tempTestDir);
         chdir($this->tempTestDir);
         shell_exec('git init');
+        $this->shouldSignGpg = shell_exec('git config --global commit.gpgsign false');
+        shell_exec('git config --global commit.gpgsign false');
         shell_exec('git config user.email "cghooks@example.com"');
         shell_exec('git config user.name "Composer Git Hooks"');
 
@@ -35,6 +39,7 @@ abstract class TestCase extends PHPUnitTestCase
 
     final public function tearDown(): void
     {
+        shell_exec('git config --global commit.gpgsign '.$this->shouldSignGpg);
         chdir('..');
         self::rmdir($this->tempTestDir);
         $this->restoreGlobalHookDir();

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -5,6 +5,7 @@ namespace BrainMaestro\GitHooks\Tests;
 use BrainMaestro\GitHooks\Commands\UpdateCommand;
 use BrainMaestro\GitHooks\Hook;
 use Symfony\Component\Console\Tester\CommandTester;
+use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @group update
@@ -19,9 +20,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester = new CommandTester(new UpdateCommand());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_hooks_that_do_not_already_exist()
     {
         $this->commandTester->execute([]);
@@ -31,9 +30,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_hooks_that_already_exist()
     {
         self::createHooks();
@@ -44,9 +41,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_custom_hooks_that_do_not_already_exist()
     {
         $customHooks = [
@@ -63,9 +58,7 @@ class UpdateCommandTest extends TestCase
         $this->assertStringContainsString("Added pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_custom_hooks_that_already_exist()
     {
         $customHooks = [
@@ -83,9 +76,7 @@ class UpdateCommandTest extends TestCase
         $this->assertStringContainsString("Updated pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_shebang_to_hooks_on_windows()
     {
         if (! is_windows()) {
@@ -104,9 +95,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
         $gitDir = 'test-git-dir';
@@ -120,9 +109,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_create_git_hooks_path_when_hooks_dir_not_exists()
     {
         $gitDir = 'test-git-dir';
@@ -139,9 +126,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
     {
         self::createHooks();
@@ -156,9 +141,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_handles_commands_defined_in_an_array()
     {
         self::createHooks();
@@ -181,9 +164,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_global_git_hooks()
     {
         $gitDir = 'test-global-git-dir';
@@ -224,9 +205,7 @@ class UpdateCommandTest extends TestCase
         self::rmdir($lockDir);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_fails_if_global_hook_dir_is_missing()
     {
         putenv('COMPOSER_HOME=');
@@ -245,9 +224,7 @@ class UpdateCommandTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function it_updates_hooks_correctly_in_a_git_worktree()
     {
         self::createHooks();

--- a/tests/UpdateCommandTest.php
+++ b/tests/UpdateCommandTest.php
@@ -4,12 +4,14 @@ namespace BrainMaestro\GitHooks\Tests;
 
 use BrainMaestro\GitHooks\Commands\UpdateCommand;
 use BrainMaestro\GitHooks\Hook;
+use PHPUnit\Framework\Attributes\Group;
 use Symfony\Component\Console\Tester\CommandTester;
 use PHPUnit\Framework\Attributes\Test;
 
 /**
  * @group update
  */
+#[Group('update')]
 class UpdateCommandTest extends TestCase
 {
     /** @var CommandTester */
@@ -20,6 +22,7 @@ class UpdateCommandTest extends TestCase
         $this->commandTester = new CommandTester(new UpdateCommand());
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_hooks_that_do_not_already_exist()
     {
@@ -30,6 +33,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_updates_hooks_that_already_exist()
     {
@@ -41,6 +45,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_custom_hooks_that_do_not_already_exist()
     {
@@ -58,6 +63,7 @@ class UpdateCommandTest extends TestCase
         $this->assertStringContainsString("Added pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_updates_custom_hooks_that_already_exist()
     {
@@ -76,6 +82,7 @@ class UpdateCommandTest extends TestCase
         $this->assertStringContainsString("Updated pre-flow-feature-start hook", $this->commandTester->getDisplay());
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_shebang_to_hooks_on_windows()
     {
@@ -95,6 +102,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_uses_a_different_git_path_if_specified()
     {
@@ -109,6 +117,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_create_git_hooks_path_when_hooks_dir_not_exists()
     {
@@ -126,6 +135,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_adds_win_bash_compat_if_the_force_windows_option_is_passed()
     {
@@ -141,6 +151,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_handles_commands_defined_in_an_array()
     {
@@ -164,6 +175,7 @@ class UpdateCommandTest extends TestCase
         }
     }
 
+    /** @test  */
     #[Test]
     public function it_updates_global_git_hooks()
     {
@@ -186,6 +198,8 @@ class UpdateCommandTest extends TestCase
      * @test
      * @group lock-dir
      */
+    #[Test]
+    #[Group('lock-dir')]
     public function it_updates_git_hooks_with_lock_dir()
     {
         $lockDir = realpath(getcwd()) . '/../lock-dir';
@@ -205,6 +219,7 @@ class UpdateCommandTest extends TestCase
         self::rmdir($lockDir);
     }
 
+    /** @test  */
     #[Test]
     public function it_fails_if_global_hook_dir_is_missing()
     {
@@ -224,6 +239,7 @@ class UpdateCommandTest extends TestCase
         );
     }
 
+    /** @test  */
     #[Test]
     public function it_updates_hooks_correctly_in_a_git_worktree()
     {


### PR DESCRIPTION
Also included a fix to make the `grep` in the cghooks of the project to be cross platform and a fix to disable gpg signing during the tests, as it otherwise fails all the tests if globally enabled (because email doesn't match)